### PR TITLE
Implement clear appointment command and fix a bug in parsing command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearAppointmentCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.AppointmentBook;
+import seedu.address.model.Model;
+
+/**
+ * Clears the appointment list.
+ */
+public class ClearAppointmentCommand extends Command {
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_SUCCESS = "Appointment list has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setAppointmentBook(new AppointmentBook());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.commands.AddInsuranceCommand;
 import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.logic.commands.ClearAppointmentCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearInsuranceCommand;
 import seedu.address.logic.commands.ClearPersonCommand;
@@ -117,13 +118,12 @@ public class AddressBookParser {
         if (arguments.trim().length() == 0) {
             return SINGLE_COMMAND_FORMAT;
         }
-
         if (arguments.trim().length() < 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
-
-
-
+        if (arguments.trim().split(" ")[0].length() != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
         return arguments.trim().substring(0, 2);
     }
 
@@ -213,6 +213,8 @@ public class AddressBookParser {
             return new EditAppointmentCommandParser().parse(arguments);
         case FindAppointmentCommand.COMMAND_WORD:
             return new FindAppointmentCommandParser().parse(arguments);
+        case ClearAppointmentCommand.COMMAND_WORD:
+            return new ClearAppointmentCommand();
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -60,7 +60,7 @@ public class AddressBookParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditPersonCommand command =
                 (EditPersonCommand) parser.parseCommand(null, EditPersonCommand.COMMAND_WORD
-                        + " " + Command.COMMAND_PERSON
+                        + " " + Command.COMMAND_PERSON + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " "
                         + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);


### PR DESCRIPTION
* Previously `list -aaaaa` behaved in the same way as `list -a`, which was not intended
* Now `list -aaaaa` will be treated as an invalid command, this also applies to commands related to other components