### PR TITLE
Fix edit/delete reflect bug

### DIFF
--- a/docs/team/zzkzzzz.md
+++ b/docs/team/zzkzzzz.md
@@ -1,46 +1,83 @@
 ---
-layout: page
-title: zzkzzzz's Project Portfolio Page
+# Zheng ZiKang's Project Portfolio Page
+- [1. New Feature](#NewFeature)
+- [2. Code contributed](#Codecontributed)
+- [3. Project management](#Projectmanagement)
+- [4. Enhancements to existing features](#existing)
+- [5. Documentation](#Documentation)
+- [6. Community](#Community)
 ---
 
-### Project: AddressBook Level 3
+## Project: Mr. Agent
 
-AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+Mr. Agent is a desktop app for managing contacts, optimized for use via a Command Line Interface (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, Mr. Agent can get your contact management tasks done faster than traditional GUI apps.
 
 Given below are my contributions to the project.
 
-* **New Feature**: Added the ability to undo/redo previous commands.
-  * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
-  * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
-  * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
-  * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
+## <a id="NewFeatures"></a>**1. New Features**
+* **New Feature**: Added Add/Delete/Edit/List Insurance Commands that allows the user to manage the Insurances.
+(Pull requests [\#29](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/29), 
+[\#35](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/35), [\#36](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/36), 
+[\#44](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/44), [\#74](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/74))
 
-* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
+* **New Feature**: Added clear Client and Insurance commands that allows the user to clear the data.
+(Pull requests [\#83](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/83))
 
-* **Code contributed**: [RepoSense link]()
+* **New Feature**: Added Sort records Commands that allows the user to sort the records by start/end date in ascending/descending order.
+(Pull request [\#91](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/91))
 
-* **Project management**:
-  * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub
+* **New Feature**: Improved and extended the command syntax more user-friendly and to match our scenario.
+(Pull request [\#24](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/24))
 
-* **Enhancements to existing features**:
-  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
-  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+* **New Feature**: ReDesign and add in click event listener for list.
+(Pull requests [\#44](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/44), 
+  [\#46](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/46))
 
-* **Documentation**:
+## <a id="Codecontributed"></a>**2. Code contributed**
+* [RepoSense link](https://github.com/AY2122S2-CS2103-F09-3/tp)
+* [Pull Request](https://github.com/AY2122S2-CS2103-F09-3/tp/pulls?q=is%3Apr+is%3Aclosed+author%3Azzkzzzz)
+
+
+## <a id="Projectmanagement"></a>**3. Project management**
+  * Managed repo Pull Requests and Issues on GitHub.
+  * Managed releases `v1.3` - `v1.5rc` (3 releases) on GitHub.
+  * Hosted weekly team meeting
+  * Helped team members to debug
+  * Helped team to improve code style and quality
+  * Set up and update project track [documentation](https://docs.google.com/document/d/1YnxPw8cAvkEcVgljEb4Ux5qUX_KnXIDYhm5BC7UsAq8/edit?usp=sharing)
+
+## <a id="existing"></a>**4. Enhancements to existing features**
+  * Redesigned and improved the GUI interface (Pull requests [\#44](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/44), 
+  [\#46](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/46), [\#74](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/74)
+  [\#116](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/116))
+  * Connected existing Person Class with Records. (Pull requests [\#61](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/61))
+  * Wrote additional tests for existing and new features to increase coverage 
+  (Pull requests [\#65](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/65), [\#91](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/91))
+
+## <a id="Documentation"></a>**5. Documentation**
   * User Guide:
-    * Added documentation for the features `delete` and `find` [\#72]()
-    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+    * Added documentation for the features Add/Delete/Edit Insurance Commands (Pull requests
+    [\#29](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/29), [\#114](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/114))
+    * Added documentation for the features Sort Records Commands 
+    (Pull requests [\#114](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/114))
+ 
   * Developer Guide:
-    * Added implementation details of the `delete` feature.
+    * Updated implementation details of the Storage component
+    (Pull requests [\#98](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/98))
+    * Added implementation details of the Sort Records Commands
+    (Pull requests [\#98](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/98), [\#108](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/108))
+    * Added implementation details of the Click event on objectListPlaceholder feature
+    (Pull requests [\#98](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/98))
+    * Updated project scope,Use case, NFR and Glossary
+    (Pull request [\#24](https://github.com/AY2122S2-CS2103-F09-3/tp/pull/24))
 
+  
+## <a id="Community"></a>**6. Community**
 * **Community**:
   * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
   * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
   * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
   * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
 
-* **Tools**:
-  * Integrated a third party library (Natty) to the project ([\#42]())
-  * Integrated a new Github plugin (CircleCI) to the team repo
 
-* _{you can add/remove categories in the list above}_
+

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -88,6 +88,8 @@ public class MainApp extends Application {
         this.logic = new LogicManager(this.model, this.storage);
 
         this.ui = new UiManager(this.logic);
+
+        logic.setUi((UiManager) this.ui);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -12,6 +12,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.insurance.Insurance;
 import seedu.address.model.person.Person;
 import seedu.address.model.record.Record;
+import seedu.address.ui.UiManager;
 
 /**
  * API of the Logic component
@@ -65,6 +66,11 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Set the Ui.
+     */
+    void setUi(UiManager ui);
 
 
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,8 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddInsuranceCommand;
+import seedu.address.logic.commands.AddPersonCommand;
 import seedu.address.logic.commands.AddRecordCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -81,6 +83,20 @@ public class LogicManager implements Logic {
             Record editedRecord = addRecordCommand.getToAdd();
             int index = this.model.getFilteredRecordList().size();
             this.ui.updateDetailPanel(editedRecord, index);
+        }
+
+        if (command instanceof AddInsuranceCommand) {
+            AddInsuranceCommand addInsuranceCommand = (AddInsuranceCommand) command;
+            Insurance editedInsurance = addInsuranceCommand.getToAdd();
+            int index = this.model.getFilteredInsuranceList().size();
+            this.ui.updateDetailPanel(editedInsurance, index);
+        }
+
+        if (command instanceof AddPersonCommand) {
+            AddPersonCommand addPersonCommand = (AddPersonCommand) command;
+            Person editedPerson = addPersonCommand.getToAdd();
+            int index = this.model.getFilteredPersonList().size();
+            this.ui.updateDetailPanel(editedPerson, index);
         }
 
         if (command instanceof EditInsuranceCommand) {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -78,6 +78,10 @@ public class LogicManager implements Logic {
     }
 
     private void updateDetail(Command command) throws CommandException, ParseException {
+        if (this.ui == null) {
+            return;
+        }
+
         if (command instanceof AddRecordCommand) {
             AddRecordCommand addRecordCommand = (AddRecordCommand) command;
             Record editedRecord = addRecordCommand.getToAdd();

--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.insurance.Insurance;
-import seedu.address.model.record.Record;
 
 /**
  * Adds a insurance to the address book.

--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.insurance.Insurance;
+import seedu.address.model.record.Record;
 
 /**
  * Adds a insurance to the address book.
@@ -35,6 +36,13 @@ public class AddInsuranceCommand extends Command {
     public AddInsuranceCommand(Insurance insurance) {
         requireNonNull(insurance);
         toAdd = insurance;
+    }
+
+    /**
+     * Returns toAdd.
+     */
+    public Insurance getToAdd() {
+        return toAdd;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-import seedu.address.model.record.Record;
 
 /**
  * Adds a person to the address book.

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.record.Record;
 
 /**
  * Adds a person to the address book.
@@ -44,6 +45,13 @@ public class AddPersonCommand extends Command {
     public AddPersonCommand(Person person) {
         requireNonNull(person);
         toAdd = person;
+    }
+
+    /**
+     * Returns toAdd.
+     */
+    public Person getToAdd() {
+        return toAdd;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
@@ -31,11 +31,18 @@ public class AddRecordCommand extends Command {
     private final Record toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Record}
+     * Creates an AddCommand to add the specified {@code Record}.
      */
     public AddRecordCommand(Record record) {
         requireNonNull(record);
         toAdd = record;
+    }
+
+    /**
+     * Returns toAdd.
+     */
+    public Record getToAdd() {
+        return toAdd;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditInsuranceCommand.java
@@ -40,9 +40,11 @@ public class EditInsuranceCommand extends Command {
 
     private final Index index;
     private final EditInsuranceDescriptor editInsuranceDescriptor;
+    private Insurance editedInsurance;
+    private Insurance insuranceToEdit;
 
     /**
-     * @param index                of the insurance in the filtered insurance list to edit
+     * @param index                   of the insurance in the filtered insurance list to edit
      * @param editInsuranceDescriptor details to edit the insurance with
      */
     public EditInsuranceCommand(Index index, EditInsuranceDescriptor editInsuranceDescriptor) {
@@ -76,8 +78,8 @@ public class EditInsuranceCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_INSURANCE_DISPLAYED_INDEX);
         }
 
-        Insurance insuranceToEdit = lastShownList.get(index.getZeroBased());
-        Insurance editedInsurance = createEditedInsurance(insuranceToEdit, editInsuranceDescriptor);
+        insuranceToEdit = lastShownList.get(index.getZeroBased());
+        editedInsurance = createEditedInsurance(insuranceToEdit, editInsuranceDescriptor);
 
         if (!insuranceToEdit.isSameInsurance(editedInsurance) && model.hasInsurance(editedInsurance)) {
             throw new CommandException(MESSAGE_DUPLICATE_INSURANCE);
@@ -86,6 +88,27 @@ public class EditInsuranceCommand extends Command {
         model.setInsurance(insuranceToEdit, editedInsurance);
         model.updateFilteredInsuranceList(PREDICATE_SHOW_ALL_INSURANCES);
         return new CommandResult(String.format(MESSAGE_EDIT_INSURANCE_SUCCESS, editedInsurance));
+    }
+
+    /**
+     * Returns the edited Insurance.
+     */
+    public Insurance getEditedInsurance() {
+        return editedInsurance;
+    }
+
+    /**
+     * Returns the insuranceToEdit.
+     */
+    public Insurance getInsuranceToEdit() {
+        return insuranceToEdit;
+    }
+
+    /**
+     * Returns the edited Insurance index.
+     */
+    public int getEditedInsuranceIndex() {
+        return index.getOneBased();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -53,6 +53,8 @@ public class EditPersonCommand extends Command {
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
+    private Person editedPerson;
+    private Person personToEdit;
 
     /**
      * @param index                of the person in the filtered person list to edit
@@ -86,6 +88,27 @@ public class EditPersonCommand extends Command {
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, originalRecords);
     }
 
+    /**
+     * Returns the edited Person.
+     */
+    public Person getEditedPerson() {
+        return editedPerson;
+    }
+
+    /**
+     * Returns the edited Person index.
+     */
+    public int getEditedPersonIndex() {
+        return index.getOneBased();
+    }
+
+    /**
+     * Returns the insuranceToEdit.
+     */
+    public Person getPersonToEdit() {
+        return personToEdit;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -95,8 +118,8 @@ public class EditPersonCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        personToEdit = lastShownList.get(index.getZeroBased());
+        editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/EditRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRecordCommand.java
@@ -34,7 +34,7 @@ public class EditRecordCommand extends Command {
             + "[" + PREFIX_REC_INSURANCEID + "INSURANCE INDEX] "
             + "[" + PREFIX_REC_STARTDATE + "START DATE] "
             + "[" + PREFIX_REC_ENDDATE + "END DATE]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example: " + COMMAND_WORD + "-r 1 "
             + PREFIX_REC_CLIENTID + "2 "
             + PREFIX_REC_INSURANCEID + "3 ";
 
@@ -46,6 +46,7 @@ public class EditRecordCommand extends Command {
 
     private final Index index;
     private final EditRecordDescriptor editRecordDescriptor;
+    private Record editedRecord;
 
     /**
      * @param index                of the record in the filtered record list to edit
@@ -89,7 +90,6 @@ public class EditRecordCommand extends Command {
             int clientIndex = Integer.parseInt(editRecordDescriptor.getClientID().get().toString());
 
             if (clientIndex >= lastPersonShownList.size()) {
-                System.out.println("person list: " + lastPersonShownList.size());
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
             ClientID clientIdName = new ClientID(lastPersonShownList.get(clientIndex - 1).getName().fullName, true);
@@ -100,7 +100,6 @@ public class EditRecordCommand extends Command {
             int recordIndex = Integer.parseInt(editRecordDescriptor.getInsuranceID().get().toString());
 
             if (recordIndex >= lastInsuranceList.size()) {
-                System.out.println("insurance list: " + lastInsuranceList.size());
                 throw new CommandException(Messages.MESSAGE_INVALID_INSURANCE_DISPLAYED_INDEX);
             }
 
@@ -122,7 +121,7 @@ public class EditRecordCommand extends Command {
         }
 
         Record recordToEdit = lastRecordShownList.get(index.getZeroBased());
-        Record editedRecord = createEditedRecord(recordToEdit, editRecordDescriptor);
+        editedRecord = createEditedRecord(recordToEdit, editRecordDescriptor);
 
         if (!recordToEdit.isSameRecord(editedRecord) && model.hasRecord(editedRecord)) {
             throw new CommandException(MESSAGE_DUPLICATE_RECORD);
@@ -132,6 +131,20 @@ public class EditRecordCommand extends Command {
         model.updateFilteredRecordList(Model.PREDICATE_SHOW_ALL_RECORDS);
         return new CommandResult(String.format(MESSAGE_EDIT_RECORD_SUCCESS, editedRecord));
 
+    }
+
+    /**
+     * Returns the edited Person.
+     */
+    public Record getEditedRecord() {
+        return editedRecord;
+    }
+
+    /**
+     * Returns the edited Record index.
+     */
+    public int getEditedRecordIndex() {
+        return index.getOneBased();
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -177,7 +177,7 @@ public class MainWindow extends UiPart<Stage> {
 
 
     /**
-     * update DetailPanel for clicked insurance card
+     * Updates DetailPanel for clicked insurance card.
      */
     public void updateInsuranceDetailPanel(Insurance insurance, int displayedIndex) {
         detailPanel.getChildren().clear();
@@ -185,7 +185,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * update DetailPanel for clicked insurance card
+     * Updates DetailPanel for clicked insurance card.
      */
     public void updatePersonDetailPanel(Person person, int displayedIndex) {
         ObservableList<Record> records = logic.getFilteredRecordList();
@@ -194,11 +194,11 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * update DetailPanel for clicked record card
+     * Updates DetailPanel for clicked record card.
      */
-    public void updateRecordDetailPanel(Record record) {
+    public void updateRecordDetailPanel(Record record, int displayedIndex) {
         detailPanel.getChildren().clear();
-        detailPanel.getChildren().add(new RecordDetailCard(record, 1).getRoot());
+        detailPanel.getChildren().add(new RecordDetailCard(record, displayedIndex).getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/RecordCard.java
+++ b/src/main/java/seedu/address/ui/RecordCard.java
@@ -38,7 +38,7 @@ public class RecordCard extends UiPart<Region> {
         cardPane.setOnMousePressed(new EventHandler<MouseEvent>() {
             public void handle(MouseEvent me) {
                 System.out.println("Mouse pressed box " + displayedIndex);
-                main.updateRecordDetailPanel(record);
+                main.updateRecordDetailPanel(record, displayedIndex);
             }
         });
     }

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -11,6 +11,9 @@ import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
+import seedu.address.model.insurance.Insurance;
+import seedu.address.model.person.Person;
+import seedu.address.model.record.Record;
 
 /**
  * The manager of the UI component.
@@ -83,6 +86,19 @@ public class UiManager implements Ui {
         showAlertDialogAndWait(Alert.AlertType.ERROR, title, e.getMessage(), e.toString());
         Platform.exit();
         System.exit(1);
+    }
+
+    /**
+     * Updates DetailPanel for edit command.
+     */
+    public void updateDetailPanel(Object obj, int index) {
+        if (obj instanceof Person) {
+            mainWindow.updatePersonDetailPanel((Person) obj, index);
+        } else if (obj instanceof Record) {
+            mainWindow.updateRecordDetailPanel((Record) obj, index);
+        } else if (obj instanceof Insurance) {
+            mainWindow.updateInsuranceDetailPanel((Insurance) obj, index);
+        }
     }
 
 }


### PR DESCRIPTION
The following bugs were fixed:
- After editing a client/insurance/records, the action will not reflect in the detail panel. The original data might still stay in the detail panel. 
- When updating a client name or insurance title, the corresponding record should be updated.